### PR TITLE
Change website title

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 
     <head>
         <meta charset="utf-8">
-        <title>TMSC 2019</title>
+        <title>Trent Mathematics and Statistics Conference 2019</title>
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
         <meta content="" name="keywords">
         <meta content="" name="description">


### PR DESCRIPTION
Changed the website title from TMSC 2019 to Trent Mathematics and Statistics Conference 2019.

This is a pull request, I just thought it looked better but let me know what you think @melissavanbussel